### PR TITLE
Make AstNode _fields compatible with AST

### DIFF
--- a/antlr_ast.py
+++ b/antlr_ast.py
@@ -7,6 +7,7 @@ from inputstream import CaseTransformInputStream
 import json
 
 from collections import OrderedDict
+import warnings
 
 
 def parse(grammar, text, start, strict=False, upper=True):
@@ -61,9 +62,15 @@ class AstNode(AST):
     _rules = []
 
     def __init__(self, _ctx=None, **kwargs):
-        # TODO: ensure key is in _fields?
+        # This makes instances compatible with tree walking
+        self.__fields = self._fields
+        self._fields = self._get_field_names()
+
         for k, v in kwargs.items():
+            if k not in self._fields:
+                warnings.warn("Key not in fields: {}".format(k))
             setattr(self, k, v)
+
         self._ctx = _ctx
 
     @classmethod
@@ -108,7 +115,7 @@ class AstNode(AST):
         return cls(ctx, **field_dict)
 
     def _get_field_names(self):
-        od = OrderedDict([(el.split("->")[-1], None) for el in self._fields])
+        od = OrderedDict([(el.split("->")[-1], None) for el in self.__fields])
         return list(od)
 
     def _get_text(self, text):

--- a/tests/test_ast_node.py
+++ b/tests/test_ast_node.py
@@ -1,0 +1,19 @@
+import pytest
+
+from antlr_ast import AstNode, parse_field_spec
+
+
+def test_double_field():
+    class Test(AstNode):
+        _fields_spec = ["a->x", "b->x"]
+
+    assert Test._fields == ["x"]
+
+
+def test_spec_parse():
+    field_spec_str = "a->x"
+    field_spec = parse_field_spec(field_spec_str)
+
+    assert field_spec.name == "x"
+    assert field_spec.origin == "a"
+    assert field_spec == ("x", "a")

--- a/tests/test_expr_ast.py
+++ b/tests/test_expr_ast.py
@@ -2,17 +2,20 @@ from antlr_ast import AstNode
 
 from tests.ExprVisitor import ExprVisitor
 
+
 class SubExpr(AstNode):
-    _fields = ['expr->expression']
+    _fields_spec = ["expr->expression"]
+
 
 class BinaryExpr(AstNode):
-    _fields = ['left', 'right', 'op']
+    _fields_spec = ["left", "right", "op"]
+
 
 class NotExpr(AstNode):
-    _fields = ['NOT->op', 'expr']
+    _fields_spec = ["NOT->op", "expr"]
+
 
 class AstVisitor(ExprVisitor):
-    
     def visitBinaryExpr(self, ctx):
         return BinaryExpr._from_fields(self, ctx)
 
@@ -25,7 +28,8 @@ class AstVisitor(ExprVisitor):
     def visitTerminal(self, ctx):
         return ctx.getText()
 
-def parse(text, start='expr', strict=False):
+
+def parse(text, start="expr", strict=False):
     from antlr4.InputStream import InputStream
     from antlr4 import FileStream, CommonTokenStream
 
@@ -37,51 +41,71 @@ def parse(text, start='expr', strict=False):
     lexer = ExprLexer(input_stream)
     token_stream = CommonTokenStream(lexer)
     parser = ExprParser(token_stream)
-    ast = AstVisitor()     
+    ast = AstVisitor()
 
     return ast.visit(getattr(parser, start)())
 
+
 def test_binary():
-    node = parse('1 + 2')
+    node = parse("1 + 2")
     assert isinstance(node, BinaryExpr)
-    assert node.left == '1'
-    assert node.right == '2'
-    assert node.op == '+'
+    assert node.left == "1"
+    assert node.right == "2"
+    assert node.op == "+"
+
 
 def test_not():
-    node = parse('not 2')
+    node = parse("not 2")
     assert isinstance(node, NotExpr)
-    assert node.expr == '2'
+    assert node.expr == "2"
+
 
 def test_subexpr():
-    node = parse('(1 + 1)')
+    node = parse("(1 + 1)")
+    assert isinstance(node, SubExpr)
     assert isinstance(node.expression, BinaryExpr)
+
+
+def test_fields():
+    assert NotExpr._fields == ["op", "expr"]
+    not_expr = parse("not 2")
+    assert not_expr._fields == ["op", "expr"]
+
+    assert SubExpr._fields == ["expression"]
+    sub_expr = parse("(1 + 1)")
+    assert sub_expr._fields == ["expression"]
+
 
 # Speaker ---------------------------------------------------------------------
 
 import pytest
 from antlr_ast import Speaker
 
-def test_speaker_default():
-    speaker = Speaker(nodes =  {'BinaryExpr': 'binary expression'},
-                      fields = {'left': 'left part'})
 
-    node = parse('1 + 1')
+def test_speaker_default():
+    speaker = Speaker(
+        nodes={"BinaryExpr": "binary expression"}, fields={"left": "left part"}
+    )
+
+    node = parse("1 + 1")
     str_tmp = "The {field_name} of the {node_name}"
 
-    assert speaker.describe(node, str_tmp, 'left') == \
-                str_tmp.format(field_name = 'left part', node_name = 'binary expression')
+    assert speaker.describe(node, str_tmp, "left") == str_tmp.format(
+        field_name="left part", node_name="binary expression"
+    )
+
 
 def test_speaker_node_cfg():
-    node_cnfg = {'name': 'binary expression', 'fields': {'left': 'left part'}}
+    node_cnfg = {"name": "binary expression", "fields": {"left": "left part"}}
 
-    speaker = Speaker(nodes =  {'BinaryExpr': node_cnfg},
-                      fields = {'left': 'should not occur!'})
+    speaker = Speaker(
+        nodes={"BinaryExpr": node_cnfg}, fields={"left": "should not occur!"}
+    )
 
-    node = parse('1 + 1')
+    node = parse("1 + 1")
     str_tmp = "The {field_name} of the {node_name}"
 
-    assert speaker.describe(node, str_tmp, 'left') == \
-                str_tmp.format(field_name = 'left part', node_name = 'binary expression')
-
+    assert speaker.describe(node, str_tmp, "left") == str_tmp.format(
+        field_name="left part", node_name="binary expression"
+    )
 


### PR DESCRIPTION
Our usage of `_fields` isn't compatible with the one Python expects.
This fixes that for AstNode instances, so it's possible to use the Python walk function.